### PR TITLE
Improve performance of tab layout

### DIFF
--- a/src/layout/elements/Chord.ts
+++ b/src/layout/elements/Chord.ts
@@ -6,7 +6,7 @@ import { Note } from "./Note";
 
 export class Chord extends LayoutElement<"Chord", types.LineElement> implements types.Chord {
   readonly type = "Chord";
-  readonly children: (types.Note | types.Stroke)[] = [];
+  readonly children: (types.Note | types.Stroke)[];
 
   constructor(readonly chord: notation.Chord) {
     // TODO use num staff lines from ancestor

--- a/src/layout/elements/Measure.ts
+++ b/src/layout/elements/Measure.ts
@@ -24,7 +24,7 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
       axis: "horizontal",
       crossAxisAlignment: "center",
       defaultFlexProps: {
-        factor: null,
+        factor: 0,
       },
     });
 

--- a/src/layout/elements/Measure.ts
+++ b/src/layout/elements/Measure.ts
@@ -2,7 +2,7 @@ import types from "..";
 import * as notation from "../../notation";
 import { NoteValue, NoteValueName } from "../../notation";
 import { STAFF_LINE_HEIGHT } from "../constants";
-import { FlexGroup, FlexProps } from "../layouts/FlexGroup";
+import { FlexGroup } from "../layouts/FlexGroup";
 import { Inches, LineElement } from "../types";
 import { Box } from "../utils/Box";
 import { Chord } from "./Chord";
@@ -23,9 +23,7 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
       box: Box.empty(),
       axis: "horizontal",
       crossAxisAlignment: "center",
-      defaultFlexProps: {
-        factor: 0,
-      },
+      defaultStretchFactor: 0,
     });
 
     const singleWholeRest =
@@ -42,7 +40,7 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
 
     if (singleWholeRest) {
       // If just a single whole rest, make this spacer stretchable to "center" the rest
-      this.addElement(Space.fromDimensions(4 * spacerWidth, spacerHeight), { factor: 1 });
+      this.addElement(Space.fromDimensions(4 * spacerWidth, spacerHeight), 1);
     } else {
       this.addElement(Space.fromDimensions(spacerWidth, spacerHeight));
     }
@@ -58,9 +56,9 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
       }
 
       if (singleWholeRest) {
-        this.addElement(Space.fromDimensions(4 * spacerWidth, spacerHeight), { factor: 1 });
+        this.addElement(Space.fromDimensions(4 * spacerWidth, spacerHeight), 1);
       } else {
-        this.addElement(Space.fromDimensions(width, spacerHeight), { factor: width });
+        this.addElement(Space.fromDimensions(width, spacerHeight), width);
       }
     }
 
@@ -71,8 +69,8 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
     this.addElement(Space.fromDimensions(0, spacerHeight));
   }
 
-  override tryAddElement(element: LineElement, flexProps?: Partial<FlexProps>) {
-    const wasAdded = super.tryAddElement(element, flexProps);
+  override tryAddElement(element: LineElement, factor?: number) {
+    const wasAdded = super.tryAddElement(element, factor);
     if (wasAdded) {
       if (element instanceof Rest || element instanceof Chord) {
         this.chords.push(element);
@@ -82,8 +80,8 @@ export class Measure extends FlexGroup<LineElement, "Measure", LineElement> {
     return wasAdded;
   }
 
-  override addElement(element: LineElement, flexProps?: Partial<FlexProps>) {
-    super.addElement(element, flexProps);
+  override addElement(element: LineElement, factor?: number) {
+    super.addElement(element, factor);
     if (element instanceof Rest || element instanceof Chord) {
       this.chords.push(element);
     }

--- a/src/layout/elements/PartHeader.ts
+++ b/src/layout/elements/PartHeader.ts
@@ -17,7 +17,7 @@ export class PartHeader extends FlexGroup<types.PageElement, "Group", types.Part
     super({
       box: new Box(0, 0, contentWidth, 0),
       axis: "vertical",
-      defaultFlexProps: { factor: 0 },
+      defaultStretchFactor: 0,
     });
 
     // Lay out the composition title, composer, etc
@@ -125,7 +125,7 @@ export class PartHeader extends FlexGroup<types.PageElement, "Group", types.Part
       axis: "horizontal",
       box: new Box(0, 0, this.contentWidth, 1),
       gap: 0.5 * DEFAULT_MARGIN,
-      defaultFlexProps: { factor: 0 },
+      defaultStretchFactor: 0,
       mainAxisSpaceDistribution: "center",
       wrap: true,
     });

--- a/src/layout/elements/PartHeader.ts
+++ b/src/layout/elements/PartHeader.ts
@@ -17,7 +17,7 @@ export class PartHeader extends FlexGroup<types.PageElement, "Group", types.Part
     super({
       box: new Box(0, 0, contentWidth, 0),
       axis: "vertical",
-      defaultFlexProps: { factor: null },
+      defaultFlexProps: { factor: 0 },
     });
 
     // Lay out the composition title, composer, etc
@@ -125,7 +125,7 @@ export class PartHeader extends FlexGroup<types.PageElement, "Group", types.Part
       axis: "horizontal",
       box: new Box(0, 0, this.contentWidth, 1),
       gap: 0.5 * DEFAULT_MARGIN,
-      defaultFlexProps: { factor: null },
+      defaultFlexProps: { factor: 0 },
       mainAxisSpaceDistribution: "center",
       wrap: true,
     });

--- a/src/layout/elements/pageline/AboveStaff.ts
+++ b/src/layout/elements/pageline/AboveStaff.ts
@@ -102,7 +102,8 @@ export class AboveStaff extends GridGroup<LineElement> {
     let endIndex = 0;
     let amount = 0;
 
-    this.staffElements.forEach(({ element }, index) => {
+    for (let index = 0; index < this.staffElements.length; ++index) {
+      const element = this.staffElements[index].element;
       if (element.type == "Space") {
         return;
       }
@@ -133,7 +134,7 @@ export class AboveStaff extends GridGroup<LineElement> {
       }
 
       endIndex = index + (options?.includeChordSpacer ? 2 : 1);
-    });
+    }
 
     if (typeof startIndex == "number" && predicateValue) {
       this.addElement(elementGenerator(predicateValue, amount), {

--- a/src/layout/elements/pageline/AboveStaff.ts
+++ b/src/layout/elements/pageline/AboveStaff.ts
@@ -1,4 +1,4 @@
-import { find, groupBy, isNumber, isUndefined, some } from "lodash";
+import { groupBy } from "lodash";
 import * as notation from "../../../notation";
 import { AccentStyle } from "../../../notation";
 import { BEAM_HEIGHT, chordWidth, STAFF_LINE_HEIGHT } from "../../constants";
@@ -37,7 +37,7 @@ export class AboveStaff extends GridGroup<LineElement> {
     const baseSize = 0.8 * STAFF_LINE_HEIGHT;
 
     this.addInterMeasureStaffDecorations(
-      (chord: notation.Chord) => some(chord.notes, "palmMute"),
+      (chord: notation.Chord) => chord.notes.some((n) => n.palmMute),
       (_hasPalmMute: boolean, amount: number) => ({
         type: amount > 1 ? "DashedLineText" : "Text",
         box: new Box(0, 0, 0, baseSize),
@@ -49,7 +49,7 @@ export class AboveStaff extends GridGroup<LineElement> {
 
     this.addInterMeasureStaffDecorations(
       (chord: notation.Chord) => {
-        return find(chord.notes, "harmonic")?.harmonicString;
+        return chord.notes.find((n) => n.harmonic)?.harmonicString;
       },
       (harmonicString: string, amount: number) => ({
         type: amount > 1 ? "DashedLineText" : "Text",
@@ -61,7 +61,7 @@ export class AboveStaff extends GridGroup<LineElement> {
     );
 
     this.addInterMeasureStaffDecorations(
-      (chord: notation.Chord) => some(chord.notes, "letRing"),
+      (chord: notation.Chord) => chord.notes.some((n) => n.letRing),
       (_letRing: boolean, amount: number) => ({
         type: amount > 1 ? "DashedLineText" : "Text",
         box: new Box(0, 0, 0, baseSize),
@@ -72,7 +72,7 @@ export class AboveStaff extends GridGroup<LineElement> {
     );
 
     this.addInterMeasureStaffDecorations(
-      (chord: notation.Chord) => some(chord.notes, "vibrato"),
+      (chord: notation.Chord) => chord.notes.some((n) => n.vibrato),
       (_vibrato: boolean, _amount: number) => new Vibrato(),
       {
         includeChordSpacer: true,
@@ -113,13 +113,13 @@ export class AboveStaff extends GridGroup<LineElement> {
       }
 
       if (newPredicateValue) {
-        if (isUndefined(startIndex)) {
+        if (startIndex === undefined) {
           startIndex = index + 1;
           predicateValue = newPredicateValue;
         } else {
           amount += 1;
         }
-      } else if (isNumber(startIndex)) {
+      } else if (typeof startIndex == "number") {
         if (predicateValue) {
           this.addElement(elementGenerator(predicateValue, amount), {
             startColumn: startIndex,
@@ -135,7 +135,7 @@ export class AboveStaff extends GridGroup<LineElement> {
       endIndex = index + (options?.includeChordSpacer ? 2 : 1);
     });
 
-    if (isNumber(startIndex) && predicateValue) {
+    if (typeof startIndex == "number" && predicateValue) {
       this.addElement(elementGenerator(predicateValue, amount), {
         startColumn: startIndex,
         endColumn: endIndex,
@@ -220,7 +220,7 @@ export class AboveStaff extends GridGroup<LineElement> {
           );
         }
 
-        const tremoloPickedNote = find(element.chord.notes, "tremoloPicking");
+        const tremoloPickedNote = element.chord.notes.find((n) => n.tremoloPicking);
         if (tremoloPickedNote) {
           const beamBoxHeight = 3 * BEAM_HEIGHT;
           const gap = 0.5 * BEAM_HEIGHT;
@@ -239,7 +239,7 @@ export class AboveStaff extends GridGroup<LineElement> {
           });
         }
 
-        const accentuatedNote = find(element.chord.notes, "accent");
+        const accentuatedNote = element.chord.notes.find((n) => n.accent);
         if (accentuatedNote && accentuatedNote.accent) {
           let accentString;
           switch (accentuatedNote.accent) {

--- a/src/layout/elements/pageline/BelowStaff.ts
+++ b/src/layout/elements/pageline/BelowStaff.ts
@@ -75,7 +75,7 @@ export class BelowStaff extends SimpleGroupElement<LineElement> {
 
   private layOutStems(measureBox: Box, beatElements: BeatElements[]) {
     for (const beatElement of beatElements) {
-      if (beatElement.type !== "Chord") {
+      if (beatElement.type === "Rest") {
         continue;
       }
 
@@ -85,7 +85,7 @@ export class BelowStaff extends SimpleGroupElement<LineElement> {
 
       // Half notes have a shorter stem on tablature
       const y = this.numBeams(beatElement) < 0 ? STAFF_LINE_HEIGHT * 2 : STAFF_LINE_HEIGHT;
-      const stemBox = new Box(measureBox.x + this.elementOffset(beatElement), y, 0, STEM_HEIGHT - y);
+      const stemBox = new Box(measureBox.x + beatElement.box.centerX, y, 0, STEM_HEIGHT - y);
 
       this.addElement(new Line(stemBox, STEM_BEAM_COLOR));
     }
@@ -105,7 +105,7 @@ export class BelowStaff extends SimpleGroupElement<LineElement> {
           y -= 0.5 * BEAM_HEIGHT * (this.numBeams(beatElement) - 1);
         }
 
-        this.addElement(new Dot(measureBox.x + this.elementOffset(beatElement), y));
+        this.addElement(new Dot(measureBox.x + beatElement.box.centerX, y));
       }
     }
   }
@@ -147,8 +147,8 @@ export class BelowStaff extends SimpleGroupElement<LineElement> {
       //   if not the first in the beat, otherwise to the right
 
       for (const [start, end] of beamRuns) {
-        let left = measureBox.x + this.elementOffset(beatElements[start]);
-        let right = measureBox.x + this.elementOffset(beatElements[end]);
+        let left = measureBox.x + beatElements[start].box.centerX;
+        let right = measureBox.x + beatElements[end].box.centerX;
         if (start === end) {
           if (start == 0) {
             right += 2 * BEAM_HEIGHT;
@@ -207,13 +207,5 @@ export class BelowStaff extends SimpleGroupElement<LineElement> {
     }
 
     return beatElements;
-  }
-
-  private elementOffset(element: BeatElements) {
-    if (element.type === "Chord" && element.children.length > 0) {
-      return element.box.x + element.children[0].box.centerX;
-    }
-    // TODO need to figure out how to best center in a rest
-    return element.box.x + 0.4 * STAFF_LINE_HEIGHT;
   }
 }

--- a/src/layout/elements/pageline/PageLine.ts
+++ b/src/layout/elements/pageline/PageLine.ts
@@ -23,6 +23,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
   private belowStaff: BelowStaff;
   private staffLines: Line[] = [];
   private staffOverlay: StaffOverlay;
+  private dirty = true;
 
   public measures: Measure[] = [];
 
@@ -66,6 +67,8 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
     if (element.type == "Measure") {
       this.measures.push(element);
     }
+
+    this.dirty = true;
     return this.staffLayout.addElement(element, flexProps);
   }
 
@@ -74,10 +77,15 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
     if (wasAdded && element.type == "Measure") {
       this.measures.push(element);
     }
+    this.dirty ||= wasAdded;
     return wasAdded;
   }
 
   layout() {
+    if (!this.dirty) {
+      return;
+    }
+
     this.staffLayout.layout();
     this.staffLayout.box.height = maxMap(this.staffLayout.children, (c) => c.box.height) ?? 0;
 
@@ -104,6 +112,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
 
     this.box.width = maxMap(this.children, (e) => e.box.width) ?? 0;
     this.box.height = this.belowStaff.box.bottom;
+    this.dirty = false;
   }
 
   private createTabGroup() {

--- a/src/layout/elements/pageline/PageLine.ts
+++ b/src/layout/elements/pageline/PageLine.ts
@@ -1,6 +1,6 @@
 import { memoize, range } from "lodash";
 import { STAFF_LINE_HEIGHT } from "../../constants";
-import { FlexGroupElement, FlexProps } from "../../layouts/FlexGroup";
+import { FlexGroupElement } from "../../layouts/FlexGroup";
 import { SimpleGroup } from "../../layouts/SimpleGroup";
 import { LineElement, Measure, Page } from "../../types";
 import { maxMap } from "../../utils";
@@ -39,7 +39,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
   }
 
   addBarLine() {
-    this.addElement(new BarLine(this.numStaffLines || 6), { factor: 0 });
+    this.addElement(new BarLine(this.numStaffLines || 6), 0);
   }
 
   reset() {
@@ -60,20 +60,20 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
     super.addElement(this.staffOverlay);
 
     this.addBarLine();
-    this.addElement(this.createTabGroup(), { factor: 0 });
+    this.addElement(this.createTabGroup(), 0);
   }
 
-  addElement(element: LineElement, flexProps?: Partial<FlexProps>) {
+  addElement(element: LineElement, factor?: number) {
     if (element.type == "Measure") {
       this.measures.push(element);
     }
 
     this.dirty = true;
-    return this.staffLayout.addElement(element, flexProps);
+    return this.staffLayout.addElement(element, factor);
   }
 
-  tryAddElement(element: LineElement, flexProps?: Partial<FlexProps>) {
-    const wasAdded = this.staffLayout.tryAddElement(element, flexProps);
+  tryAddElement(element: LineElement, factor?: number) {
+    const wasAdded = this.staffLayout.tryAddElement(element, factor);
     if (wasAdded && element.type == "Measure") {
       this.measures.push(element);
     }
@@ -123,9 +123,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
       box: new Box(0, 0.5 * STAFF_LINE_HEIGHT, width, STAFF_LINE_HEIGHT * (this.numStaffLines - 1)),
       axis: "vertical",
       mainAxisSpaceDistribution: "center",
-      defaultFlexProps: {
-        factor: 0,
-      },
+      defaultStretchFactor: 0,
     });
 
     for (const value of ["T", "A", "B"]) {

--- a/src/layout/elements/pageline/PageLine.ts
+++ b/src/layout/elements/pageline/PageLine.ts
@@ -38,7 +38,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
   }
 
   addBarLine() {
-    this.addElement(new BarLine(this.numStaffLines || 6), { factor: null });
+    this.addElement(new BarLine(this.numStaffLines || 6), { factor: 0 });
   }
 
   reset() {
@@ -59,7 +59,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
     super.addElement(this.staffOverlay);
 
     this.addBarLine();
-    this.addElement(this.createTabGroup(), { factor: null });
+    this.addElement(this.createTabGroup(), { factor: 0 });
   }
 
   addElement(element: LineElement, flexProps?: Partial<FlexProps>) {
@@ -114,6 +114,9 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
       box: new Box(0, 0.5 * STAFF_LINE_HEIGHT, width, STAFF_LINE_HEIGHT * (this.numStaffLines - 1)),
       axis: "vertical",
       mainAxisSpaceDistribution: "center",
+      defaultFlexProps: {
+        factor: 0,
+      },
     });
 
     for (const value of ["T", "A", "B"]) {
@@ -125,8 +128,7 @@ export class PageLine extends SimpleGroup<LineElement, "PageLine", Page> {
           style: {
             userSelect: "none",
           },
-        }),
-        { factor: null }
+        })
       );
     }
 

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -40,7 +40,7 @@ function layOutPart(score: notation.Score, part: notation.Part): Part {
   const contentWidth = page.content.box.width;
   const partHeader = new PartHeader(score, part, contentWidth);
   partHeader.layout();
-  page.content.addElement(partHeader, { factor: 0 });
+  page.content.addElement(partHeader, 0);
 
   let isFirstLine = true;
   let line = new PageLine(new Box(0, 0, contentWidth, 0), part.lineCount);
@@ -53,10 +53,10 @@ function layOutPart(score: notation.Score, part: notation.Part): Part {
     // start a new page.
 
     if (isFirstLine) {
-      line.addElement(measure, { factor: measureToLayOut.chords.length });
+      line.addElement(measure, measureToLayOut.chords.length);
       line.addBarLine();
       isFirstLine = false;
-    } else if (line.tryAddElement(measure, { factor: measureToLayOut.chords.length })) {
+    } else if (line.tryAddElement(measure, measureToLayOut.chords.length)) {
       line.addBarLine();
     } else {
       line.layout();
@@ -68,7 +68,7 @@ function layOutPart(score: notation.Score, part: notation.Part): Part {
       }
 
       line = new PageLine(new Box(0, 0, contentWidth, 0), part.lineCount);
-      line.addElement(measure, { factor: measureToLayOut.chords.length });
+      line.addElement(measure, measureToLayOut.chords.length);
       line.addBarLine();
       isFirstLine = true;
     }

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -40,7 +40,7 @@ function layOutPart(score: notation.Score, part: notation.Part): Part {
   const contentWidth = page.content.box.width;
   const partHeader = new PartHeader(score, part, contentWidth);
   partHeader.layout();
-  page.content.addElement(partHeader, { factor: null });
+  page.content.addElement(partHeader, { factor: 0 });
 
   let isFirstLine = true;
   let line = new PageLine(new Box(0, 0, contentWidth, 0), part.lineCount);

--- a/src/layout/layouts/FlexGroup.ts
+++ b/src/layout/layouts/FlexGroup.ts
@@ -1,4 +1,4 @@
-import { defaults, last } from "lodash";
+import { last } from "lodash";
 import types, { Alignment } from "..";
 import { Box } from "../utils/Box";
 
@@ -89,10 +89,11 @@ export abstract class FlexGroup<
   constructor(config?: Partial<FlexGroupConfig>) {
     this.gap = config?.gap ?? 0;
     this.box = config?.box ?? Box.empty();
-    this.defaultFlexProps = defaults(config?.defaultFlexProps, {
+    this.defaultFlexProps = {
       factor: 1,
       originalBox: Box.empty(),
-    });
+      ...config?.defaultFlexProps,
+    };
 
     if (config?.axis == "vertical") {
       this.startAttribute = { main: "y", cross: "x" };
@@ -123,7 +124,11 @@ export abstract class FlexGroup<
 
     element.parent = this;
     this.children.push(element);
-    this.flexProps.push(defaults({ originalBox: element.box }, flexProps, this.defaultFlexProps));
+    this.flexProps.push({
+      ...this.defaultFlexProps,
+      ...flexProps,
+      originalBox: element.box,
+    });
   }
 
   // TODO if we could configure this group with "wraps", we could get something like flex-wrap in CSS and not need `tryAddElement`

--- a/src/layout/layouts/FlexGroup.ts
+++ b/src/layout/layouts/FlexGroup.ts
@@ -154,15 +154,6 @@ export abstract class FlexGroup<
     return true;
   }
 
-  popElement(): T | undefined {
-    this.flexProps.pop();
-    const element = this.children.pop();
-    if (element) {
-      element.parent = null;
-    }
-    return element;
-  }
-
   /**
    * Reposition and scale all children so that they fill this flex group's box
    */

--- a/src/layout/layouts/FlexGroup.ts
+++ b/src/layout/layouts/FlexGroup.ts
@@ -3,12 +3,8 @@ import types, { Alignment } from "..";
 import { Box } from "../utils/Box";
 
 export type FlexProps = {
-  /**
-   * The stretch factor, which impacts how this element's dimensions will be stretched along the main axis.
-   *
-   * If null, no stretching. Otherwise, the basis will act as a "weight" in the
-   */
-  factor: number | null;
+  /** The stretch factor, which impacts how this element's dimensions will be stretched along the main axis. */
+  factor: number;
 
   /** @private */
   originalBox: Box;
@@ -17,24 +13,16 @@ export type FlexProps = {
 export type FlexGroupConfig = {
   box: Box;
 
-  /**
-   *  The gap between elements.
-   */
+  /** The gap between elements. */
   gap: number;
 
-  /**
-   * Default flex props when adding elements.
-   */
+  /** Default flex props when adding elements. */
   defaultFlexProps: Partial<FlexProps>;
 
-  /**
-   * The direction of the main axis.
-   */
+  /** The direction of the main axis. */
   axis: "vertical" | "horizontal";
 
-  /**
-   * Wrap elements that overflow the main axis size.
-   */
+  /** Wrap elements that overflow the main axis size. */
   wrap: boolean;
 
   /**
@@ -209,9 +197,9 @@ export abstract class FlexGroup<
       const childrenWidth = this.children
         .slice(startIndex, index)
         .reduce((width, c) => width + c.box[this.dimensionAttribute.main], 0);
-      const factorsSum = this.flexProps.slice(startIndex, index).reduce((sum, p) => sum + (p.factor ?? 0), 0);
       const extraSpace = this.box[this.dimensionAttribute.main] - childrenWidth - (index - startIndex - 1) * this.gap;
 
+      let factorsSum = this.flexProps.slice(startIndex, index).reduce((sum, p) => sum + p.factor, 0);
       let mainAxisStart: number;
       if (factorsSum == 0) {
         // Space distribution only makes sense when there's no stretchable items (i.e., factorsSum == 0) because otherwise
@@ -227,6 +215,8 @@ export abstract class FlexGroup<
             mainAxisStart = extraSpace;
             break;
         }
+
+        factorsSum = 1;
       } else {
         mainAxisStart = 0;
       }
@@ -238,9 +228,7 @@ export abstract class FlexGroup<
         const props = this.flexProps[childIndex];
 
         child.box[this.startAttribute.main] = mainAxisStart;
-        if (props.factor) {
-          child.box[this.dimensionAttribute.main] += extraSpace * (props.factor / factorsSum);
-        }
+        child.box[this.dimensionAttribute.main] += extraSpace * (props.factor / factorsSum);
 
         child.layout?.();
 

--- a/src/layout/utils/index.ts
+++ b/src/layout/utils/index.ts
@@ -96,19 +96,22 @@ export function minMap<T, MinT>(
  * @returns `undefined` if the array is empty, otherwise the max value in the
  */
 export function maxMap<T, MaxT>(
-  collection: Iterable<T>,
+  collection: ReadonlyArray<T>,
   mapper: (v: T) => MaxT,
   lessThan: (a: MaxT, b: MaxT) => boolean = (a, b) => a < b
 ): MaxT | undefined {
-  let maxValue: MaxT | undefined;
-  for (const v of collection) {
-    const value = mapper(v);
-    if (maxValue === undefined) {
-      maxValue = value;
-    } else if (lessThan(maxValue, value)) {
+  if (collection.length == 0) {
+    return undefined;
+  }
+
+  let maxValue: MaxT | undefined = mapper(collection[0]);
+  for (let index = 1; index < collection.length; ++index) {
+    const value = mapper(collection[index]);
+    if (lessThan(maxValue, value)) {
       maxValue = value;
     }
   }
+
   return maxValue;
 }
 

--- a/src/layout/utils/index.ts
+++ b/src/layout/utils/index.ts
@@ -143,7 +143,7 @@ export const numCharsToRepresent = (v: number): number => {
 /**
  * Find runs of elements in a bigger list.
  *
- * @param values the list of value sto find runs in
+ * @param values the list of values to find runs in
  * @param partOfRun a function that determines if a given element should be part of a run
  *
  * @returns a list of `[start, end]` tuples for all the runs in the given list

--- a/src/notation/note.ts
+++ b/src/notation/note.ts
@@ -112,7 +112,28 @@ export interface NoteOptions {
 }
 
 export class Note {
-  constructor(readonly options: NoteOptions) {}
+  private text: string;
+
+  constructor(readonly options: NoteOptions) {
+    this.text = (() => {
+      let text;
+      if (this.dead) {
+        text = "x";
+      } else if (this.tie && this.tie.previous) {
+        text = "";
+      } else if (this.placement) {
+        text = this.placement.fret.toString();
+      } else {
+        return "";
+      }
+
+      if (this.ghost) {
+        text = `(${text})`;
+      }
+
+      return text;
+    })();
+  }
 
   get pitch() {
     return this.options.pitch;
@@ -206,22 +227,7 @@ export class Note {
   }
 
   toString() {
-    let text;
-    if (this.dead) {
-      text = "x";
-    } else if (this.tie && this.tie.previous) {
-      text = "";
-    } else if (this.placement) {
-      text = this.placement.fret.toString();
-    } else {
-      return "";
-    }
-
-    if (this.ghost) {
-      text = `(${text})`;
-    }
-
-    return text;
+    return this.text;
   }
 
   /**

--- a/src/playback/SoundFont.ts
+++ b/src/playback/SoundFont.ts
@@ -1,4 +1,4 @@
-import { compact, defaults, uniqBy } from "lodash";
+import { compact, uniqBy } from "lodash";
 import { BufferCursor, NumberType } from "../loaders/util/BufferCursor";
 import * as notation from "../notation";
 import { Instrument } from "./instruments/Instrument";
@@ -186,8 +186,14 @@ export class SoundFont {
             {
               ...sampleInfo,
               buffer,
-              generators: defaults({}, zone.generators, globalZone?.generators),
-              modulators: defaults({}, zone.modulators, globalZone?.modulators),
+              generators: {
+                ...globalZone?.generators,
+                ...zone.generators,
+              },
+              modulators: {
+                ...globalZone?.modulators,
+                ...zone.modulators,
+              },
             },
           ];
         } catch (error) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,19 +6,19 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => {
   let https: TlsOptions | false = false;
-  if (mode !== "production") {
-    const certFileExists = await fs
-      .access("muzart.dev+4.pem")
-      .then(() => true)
-      .catch(() => false);
+  // if (mode !== "production") {
+  const certFileExists = await fs
+    .access("muzart.dev+4.pem")
+    .then(() => true)
+    .catch(() => false);
 
-    if (certFileExists) {
-      https = {
-        cert: "muzart.dev+4.pem",
-        key: "muzart.dev+4-key.pem",
-      };
-    }
+  if (certFileExists) {
+    https = {
+      cert: "muzart.dev+4.pem",
+      key: "muzart.dev+4-key.pem",
+    };
   }
+  // }
 
   return {
     resolve: {
@@ -43,7 +43,9 @@ export default defineConfig(async ({ mode }) => {
     },
 
     preview: {
-      port: 3002,
+      port: 3001,
+      host: "muzart.dev",
+      https,
     },
   };
 });


### PR DESCRIPTION
See individual commits for the specific improvements. The biggest win was from avoiding doing the page line layout twice.

\# samples = 200

|  | average (ms) | median (ms) |
| - | - | - |
| **before** | 140 | 128 |
| **after** | 55 | 57 |